### PR TITLE
Fix error on non-default postgres schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+schemup.egg-info
+*.pyc

--- a/schemup/dbs/postgres.py
+++ b/schemup/dbs/postgres.py
@@ -40,23 +40,11 @@ class PostgresSchema(object):
     def ensureSchemaTable(self):
         cur = self.conn.cursor()
         cur.execute(
-            "SELECT COUNT(*)"
-            " FROM information_schema.tables"
-            " WHERE table_name = 'schemup_tables'")
-        
-        if cur.fetchone()[0]:
-            return
-        
-        print "Creating schema table..."
-        cur.execute(
-            "CREATE TABLE schemup_tables ("
+            "CREATE TABLE IF NOT EXISTS schemup_tables ("
             " table_name VARCHAR NOT NULL,"
             " version VARCHAR NOT NULL,"
             " is_current BOOLEAN NOT NULL DEFAULT 'f',"
             " schema TEXT)")
-        
-        self.conn.commit()
-        
 
     def clearSchemaTable(self):
         self.execute("DELETE FROM schemup_tables")


### PR DESCRIPTION
```
>>> conn = psycopg2.connect(url)
>>> conn.cursor().execute("CREATE SCHEMA foo")
>>> dbSchema = postgres.PostgresSchema(conn)
>>> dbSchema.ensureSchemaTable()
Traceback (most recent call last):
  File ".../schemup/schemup/validator.py", line 23, in findSchemaMismatches
    for tableName, expectedSchema in dbSchema.getVersionedTableSchemas():
  File ".../schemup/schemup/dbs/postgres.py", line 88, in getVersionedTableSchemas
    "SELECT table_name, schema"
psycopg2.ProgrammingError: relation "schemup_tables" does not exist
LINE 1: SELECT table_name, schema FROM schemup_tables WHERE is_curre...
```
Use `CREATE TABLE IF NOT EXISTS` to skip checking against `information_schema.tables`. Requires Postgres 9.1